### PR TITLE
fix: 修复config字段编写错误导致的获取抖音评论条数bug

### DIFF
--- a/module/platform/douyin/douyin.js
+++ b/module/platform/douyin/douyin.js
@@ -32,7 +32,7 @@ export default class DouYin extends Base {
         })
         const CommentsData = await getDouyinData('评论数据', Config.cookies.douyin, {
           aweme_id: data.aweme_id,
-          number: Config.douyin.numcomment,
+          number: Config.douyin.numcomments,
           typeMode: 'strict'
         })
         this.is_slides = VideoData.aweme_detail.is_slides === true


### PR DESCRIPTION
numcomment应为numcomments,
缺少一个s导致每次都获取了50条评论