### PR TITLE
fix: 修复fetchDynamicCard废弃导致的B站动态解析失败

### DIFF
--- a/module/platform/bilibili/bilibili.js
+++ b/module/platform/bilibili/bilibili.js
@@ -362,14 +362,12 @@ export class Bilibili extends Base {
         case 'dynamic_info': {
           if (!hasBilibiliContent('动态')) break
           const dynamicInfo = await this.amagi.getBilibiliData('动态详情数据', { dynamic_id: iddata.dynamic_id, typeMode: 'strict' })
-          const dynamicInfoCard = await this.amagi.getBilibiliData('动态卡片数据', { dynamic_id: dynamicInfo.data.data.item.id_str, typeMode: 'strict' })
           const commentsData = dynamicInfo.data.data.item.type !== DynamicType.LIVE_RCMD && Config.bilibili.bilibilinumcomments && Config.bilibili?.bilibilinumcomments > 0 && await this.amagi.getBilibiliData('评论数据', {
             type: mapping_table(dynamicInfo.data.data.item.type),
-            oid: oid(dynamicInfo.data, dynamicInfoCard.data),
+            oid: oid(dynamicInfo.data),
             number: Config.bilibili.bilibilinumcomments,
             typeMode: 'strict'
           })
-          const dynamicCARD = JSON.parse(dynamicInfoCard.data.data.card.card)
           const userProfileData = await this.amagi.getBilibiliData('用户主页数据', { host_mid: dynamicInfo.data.data.item.modules.module_author.mid, typeMode: 'strict' })
 
           switch (dynamicInfo.data.data.item.type) {
@@ -435,8 +433,6 @@ export class Bilibili extends Base {
                 await this.e.reply(img)
               }
 
-              const dynamicCARD = JSON.parse(dynamicInfoCard.data.data.card.card)
-
               if ('topic' in dynamicInfo.data.data.item.modules.module_dynamic && dynamicInfo.data.data.item.modules.module_dynamic.topic !== null) {
                 const name = dynamicInfo.data.data.item.modules.module_dynamic.topic?.name
                 dynamicInfo.data.data.item.modules.module_dynamic.major.opus.summary.rich_text_nodes.unshift({
@@ -452,8 +448,8 @@ export class Bilibili extends Base {
               }
 
               await this.e.reply(await Render('bilibili/dynamic/DYNAMIC_TYPE_DRAW', {
-                image_url: cover(dynamicCARD.item.pictures),
-                // TIP: 2025/08/20, 动态卡片数据中，图文动态的描述文本在 major.opus.summary 中
+                image_url: cover(pics),
+                // 动态详情数据中，图文动态的描述文本在 major.opus.summary 中
                 text: dynamicInfo.data.data.item.modules.module_dynamic.major
                   ? replacetext(
                     br(dynamicInfo.data.data.item.modules.module_dynamic.major.opus?.summary?.text || ''),
@@ -559,15 +555,14 @@ export class Bilibili extends Base {
                   break
                 }
                 case DynamicType.DRAW: {
-                  const dynamicCARD2 = await this.amagi.getBilibiliData('动态卡片数据', { dynamic_id: dynamicInfo.data.data.item.orig.id_str, typeMode: 'strict' })
-                  const cardData = JSON.parse(dynamicCARD2.data.data.card.card)
                   const summary = dynamicInfo.data.data.item.orig.modules.module_dynamic.major.opus.summary
                   data = {
                     username: checkvip(dynamicInfo.data.data.item.orig.modules.module_author),
                     create_time: Common.convertTimestampToDateTime(dynamicInfo.data.data.item.orig.modules.module_author.pub_ts),
                     avatar_url: dynamicInfo.data.data.item.orig.modules.module_author.face,
                     text: replacetext(br(summary?.text || ''), summary?.rich_text_nodes || []),
-                    image_url: cardData.item.pictures ? cover(cardData.item.pictures) : [],
+                    image_url: cover(dynamicInfo.data.data.item.orig.modules.module_dynamic.major?.opus?.pics ||
+                      dynamicInfo.data.data.item.orig.modules.module_dynamic.major?.draw?.items || []),
                     decoration_card: generateDecorationCard(dynamicInfo.data.data.item.orig.modules.module_author.decoration_card),
                     frame: dynamicInfo.data.data.item.orig.modules.module_author.pendant.image
                   }
@@ -635,8 +630,6 @@ export class Bilibili extends Base {
               if (dynamicInfo.data.data.item.modules.module_dynamic.major.type === 'MAJOR_TYPE_ARCHIVE') {
                 const bvid = dynamicInfo.data.data.item.modules.module_dynamic.major.archive.bvid
                 const INFODATA = await getBilibiliData('单个视频作品数据', '', { bvid, typeMode: 'strict' })
-                const dycrad = dynamicInfoCard.data.data.card && dynamicInfoCard.data.data.card.card && JSON.parse(dynamicInfoCard.data.data.card.card)
-
                 Config.bilibili.bilibilinumcomments && commentsData && await this.e.reply(
                   await Render('bilibili/comment', {
                     Type: '动态',
@@ -652,12 +645,12 @@ export class Bilibili extends Base {
                   {
                     image_url: [{ image_src: INFODATA.data.data.pic }],
                     text: br(INFODATA.data.data.title),
-                    desc: br(dycrad.desc),
+                    desc: br(INFODATA.data.data.desc || ''),
                     dianzan: Common.count(INFODATA.data.data.stat.like),
                     pinglun: Common.count(INFODATA.data.data.stat.reply),
                     share: Common.count(INFODATA.data.data.stat.share),
-                    view: Common.count(dycrad.stat.view),
-                    coin: Common.count(dycrad.stat.coin),
+                    view: Common.count(INFODATA.data.data.stat.view),
+                    coin: Common.count(INFODATA.data.data.stat.coin),
                     duration_text: dynamicInfo.data.data.item.modules.module_dynamic.major.archive.duration_text,
                     create_time: Common.convertTimestampToDateTime(INFODATA.data.data.ctime),
                     avatar_url: INFODATA.data.data.owner.face,
@@ -677,6 +670,7 @@ export class Bilibili extends Base {
             }
             /** 直播动态 */
             case DynamicType.LIVE_RCMD: {
+              const dynamicCARD = JSON.parse(dynamicInfo.data.data.item.modules.module_dynamic.major.live_rcmd.content)
               const userINFO = await getBilibiliData('用户主页数据', '', { host_mid: dynamicInfo.data.data.item.modules.module_author.mid, typeMode: 'strict' })
               img = await Render('bilibili/dynamic/DYNAMIC_TYPE_LIVE_RCMD',
                 {
@@ -1115,7 +1109,7 @@ export const cover = (pic) => {
   // 遍历dycrad.item.pictures数组，将每个图片的img_src存入对象，并将该对象加入imgArray
   for (const i of pic) {
     const obj = {
-      image_src: i.img_src
+      image_src: i.img_src || i.src || i.url
     }
     imgArray.push(obj)
   }
@@ -1194,17 +1188,18 @@ function mapping_table(type) {
 
 /**
  * @param {import ('@ikenxuan/amagi').BiliDynamicInfo<DynamicType>} dynamicINFO 
- * @param {import ('@ikenxuan/amagi').BiliDynamicCard} dynamicInfoCard 
  * @returns 
  */
-const oid = (dynamicINFO, dynamicInfoCard) => {
+const oid = (dynamicINFO) => {
   switch (dynamicINFO.data.item.type) {
     case 'DYNAMIC_TYPE_WORD':
     case 'DYNAMIC_TYPE_FORWARD': {
       return dynamicINFO.data.item.id_str
     }
     default: {
-      return dynamicInfoCard.data.card.desc.rid.toString()
+      return dynamicINFO.data.item.basic?.comment_id_str ||
+        dynamicINFO.data.item.basic?.rid_str ||
+        dynamicINFO.data.item.id_str
     }
   }
 }

--- a/module/platform/bilibili/push.js
+++ b/module/platform/bilibili/push.js
@@ -180,8 +180,7 @@ export class Bilibilipush extends Base {
         let send_video = true
         /** @type {import ('@kaguyajs/trss-yunzai-types').icqq.segment[]} */
         let img = []
-        const dynamicCARDINFO = await this.amagi?.getBilibiliData('动态卡片数据', { dynamic_id: dynamicId, typeMode: 'strict' })
-        const dycrad = dynamicCARDINFO?.data.data.card && dynamicCARDINFO.data.data.card.card && JSON.parse(dynamicCARDINFO.data.data.card.card)
+        let dycrad
 
         if (!skip) {
           const userINFO = await this.amagi?.getBilibiliData('用户主页数据', { host_mid: dynamicItem.host_mid, typeMode: 'strict' })
@@ -205,7 +204,8 @@ export class Bilibilipush extends Base {
               }
               img = await Render('bilibili/dynamic/DYNAMIC_TYPE_DRAW',
                 {
-                  image_url: dycrad?.item?.pictures && cover(dycrad.item.pictures),
+                  image_url: cover(dynamicItem.Dynamic_Data.modules.module_dynamic.major?.opus?.pics ||
+                    dynamicItem.Dynamic_Data.modules.module_dynamic.major?.draw?.items || []),
                   text: replacetext(
                     br(
                       dynamicItem.Dynamic_Data.modules.module_dynamic.major?.opus?.summary?.text || ''),
@@ -266,6 +266,7 @@ export class Bilibilipush extends Base {
               if (dynamicItem.Dynamic_Data.modules.module_dynamic.major?.type === 'MAJOR_TYPE_ARCHIVE') {
                 const bvid = dynamicItem.Dynamic_Data?.modules.module_dynamic.major?.archive?.bvid || ''
                 const INFODATA = await getBilibiliData('单个视频作品数据', '', { bvid, typeMode: 'strict' })
+                dycrad = INFODATA.data.data
 
                 if (INFODATA.data.data.redirect_url) {
                   send_video = false
@@ -301,6 +302,7 @@ export class Bilibilipush extends Base {
             }
             /** 处理直播动态 */
             case DynamicType.LIVE_RCMD: {
+              dycrad = JSON.parse(dynamicItem.Dynamic_Data.modules.module_dynamic.major.live_rcmd.content)
               img = await Render('bilibili/dynamic/DYNAMIC_TYPE_LIVE_RCMD',
                 {
                   image_url: [{ image_src: dycrad.live_play_info.cover }],
@@ -340,15 +342,14 @@ export class Bilibilipush extends Base {
                   break
                 }
                 case DynamicType.DRAW: {
-                  const dynamicCARD = await getBilibiliData('动态卡片数据', Config.cookies.bilibili || '', { dynamic_id: dynamicItem.Dynamic_Data.orig.id_str, typeMode: 'strict' })
-                  const cardData = JSON.parse(dynamicCARD.data.data.card.card)
                   const summary = dynamicItem.Dynamic_Data.orig.modules.module_dynamic.major.opus.summary
                   param = {
                     username: checkvip(dynamicItem.Dynamic_Data.orig.modules.module_author),
                     create_time: Common.convertTimestampToDateTime(dynamicItem.Dynamic_Data.orig.modules.module_author.pub_ts),
                     avatar_url: dynamicItem.Dynamic_Data.orig.modules.module_author.face,
                     text: replacetext(br(summary?.text || ''), summary?.rich_text_nodes || []),
-                    image_url: cardData.item.pictures ? cover(cardData.item.pictures) : [],
+                    image_url: cover(dynamicItem.Dynamic_Data.orig.modules.module_dynamic.major?.opus?.pics ||
+                      dynamicItem.Dynamic_Data.orig.modules.module_dynamic.major?.draw?.items || []),
                     decoration_card: generateDecorationCard(dynamicItem.Dynamic_Data.orig.modules.module_author.decoration_card),
                     frame: dynamicItem.Dynamic_Data.orig.modules.module_author.pendant.image
                   }
@@ -505,7 +506,7 @@ export class Bilibilipush extends Base {
                       playUrlDash.video = simplify
                       correctList = await bilibiliProcessVideos({
                         accept_description: playUrlPayload.accept_description,
-                        bvid: dynamicCARDINFO.data.data.card.desc.bvid,
+                        bvid: dycrad.bvid,
                         qn: Config.bilibili.push.pushVideoQuality,
                         maxAutoVideoSize: Config.bilibili.push.pushMaxAutoVideoSize
                       }, simplify, playUrlDash.audio?.[0]?.base_url || '')
@@ -515,7 +516,7 @@ export class Bilibilipush extends Base {
                       videoSize = await getvideosize(
                         correctList.videoList?.[0]?.base_url || '',
                         playUrlDash.audio?.[0]?.base_url || '',
-                        dynamicCARDINFO.data.data.card?.desc?.bvid || ''
+                        dycrad.bvid || ''
                       )
                       if ((Config.upload.usefilelimit && Number(videoSize) > Number(Config.upload.filelimit)) && !Config.upload.compress) {
                         Bot?.[botId]?.pickGroup(groupId) && await Bot?.[botId]?.pickGroup(groupId)?.sendMsg(
@@ -527,7 +528,7 @@ export class Bilibilipush extends Base {
                         break
                       }
                       logger.mark(`当前处于自动推送状态，解析到的视频大小为 ${logger.yellow(Number(videoSize))} MB`)
-                      const infoData = await this.amagi.getBilibiliData('单个视频作品数据', { bvid: dynamicCARDINFO.data.data.card.desc.bvid, typeMode: 'strict' })
+                      const infoData = await this.amagi.getBilibiliData('单个视频作品数据', { bvid: dycrad.bvid, typeMode: 'strict' })
                       const mp4File = await downloadFile(
                         playUrlDash.video?.[0]?.base_url,
                         {


### PR DESCRIPTION
## 关联 Issue

Fixes ikenxuan/kkkkkk-10086#109

## 变更背景

自 `@ikenxuan/amagi` v6.1.3 起，B 站官方已删除原动态卡片接口，
`fetchDynamicCard` 调用会直接返回 `APIError`，导致 B 站动态解析及动态推送失败。

相关变更说明：
https://amagi-docs.vercel.app/docs/changelog/6.1.3

## 变更内容

- 移除动态解析中的“动态卡片数据”请求。
- 移除动态推送中的“动态卡片数据”请求。
- 使用现有动态详情数据获取：
  - 图文动态图片
  - 转发图文图片
  - 直播动态信息
  - 评论所需的 `oid`
- 视频动态复用已有的“单个视频作品数据”，获取视频描述、统计数据及 `bvid`。
- 兼容动态详情中不同图片字段的 URL 格式。

## 影响范围

仅修改以下两个原有文件：

- `module/platform/bilibili/bilibili.js`
- `module/platform/bilibili/push.js`

## 验证情况

- [x] `bilibili.js` 通过 `node --check`
- [x] `push.js` 通过 `node --check`
- [x] `git diff --check` 通过
- [x] ESLint 无错误
- [x] 确认代码中不再引用 `fetchDynamicCard` 或“动态卡片数据”
- [x] 经测试动态解析成功
<img width="765" height="1971" alt="image" src="https://github.com/user-attachments/assets/c6923a98-842e-45f2-8767-9c2e5492b6c7" />