### PR TITLE
fix: 迁移小红书 Amagi API 至 fetcher

### DIFF
--- a/module/platform/xiaohongshu/xiaohongshu.js
+++ b/module/platform/xiaohongshu/xiaohongshu.js
@@ -130,7 +130,7 @@ export class Xiaohongshu extends Base {
     }
 
     const sendContent = normalizeSendContent()
-    const noteData = await this.amagi.xiaohongshu.api.getNote({
+    const noteData = await this.amagi.xiaohongshu.fetcher.fetchNoteDetail({
       typeMode: 'strict',
       note_id: data.note_id,
       xsec_token: data.xsec_token
@@ -141,7 +141,7 @@ export class Xiaohongshu extends Base {
     let emojiData = []
     if (sendContent.includes('info') || sendContent.includes('comment')) {
       try {
-        const emojiList = await this.amagi.xiaohongshu.api.getEmojiList({ typeMode: 'strict' })
+        const emojiList = await this.amagi.xiaohongshu.fetcher.fetchEmojiList({ typeMode: 'strict' })
         emojiData = buildXiaohongshuEmojiList(emojiList)
       } catch (error) {
         logger.debug(`[小红书] 获取表情列表失败，使用纯文本渲染: ${error?.message || error}`)
@@ -168,7 +168,7 @@ export class Xiaohongshu extends Base {
     }
 
     if (sendContent.includes('comment')) {
-      const commentData = await this.amagi.xiaohongshu.api.getComments({
+      const commentData = await this.amagi.xiaohongshu.fetcher.fetchNoteComments({
         typeMode: 'strict',
         note_id: data.note_id,
         xsec_token: data.xsec_token || ''


### PR DESCRIPTION
## 变更内容

- `getNote` 迁移至 `fetchNoteDetail`
- `getComments` 迁移至 `fetchNoteComments`
- `getEmojiList` 迁移至 `fetchEmojiList`
- 统一使用 `client.xiaohongshu.fetcher`

## 变更原因

Amagi v6 已废弃 `getXiaohongshuData` 及其兼容 API，并将在 v7 移除。本次迁移可修复小红书内容解析失败问题。

## 验证

- 通过 `node --check`
- 通过 `git diff --check`
- 未改变请求参数及响应处理逻辑
- 测试成功解析
<img width="521" height="1871" alt="1784712405600_d" src="https://github.com/user-attachments/assets/ad1ab5e5-4ec3-412e-935b-fe5b11a3fe3d" />

## Summary by Sourcery

增强：
- 使用基于 fetcher 的笔记详情、评论和表情列表获取函数替换旧版小红书 API 调用，以标准化数据访问。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace legacy Xiaohongshu API calls with fetcher-based note detail, comment, and emoji list fetch functions to standardize data access.

</details>