### PR TITLE
fix: 修复 B站用户 UID 上限过小导致大 UID 无法输入的问题

### DIFF
--- a/guoba.support.js
+++ b/guoba.support.js
@@ -207,7 +207,7 @@ const bilibiliPushListSchema = {
     multiple: true,
     schemas: [
       sw('switch', '是否启用'),
-      num('host_mid', '用户 UID', 1, 999999999999, ''),
+      num('host_mid', '用户 UID', 1, Number.MAX_SAFE_INTEGER, ''),
       {
         field: 'group_id',
         label: '推送群和推送账号',


### PR DESCRIPTION
fix: 扩大 B站用户 UID 输入上限至 Number.MAX_SAFE_INTEGER

原上限为 999999999999（12位），当前B站用户UID最大16位 超出此范围， 导致在 Guoba 面板中无法正常输入。现改为 JS 安全整数最大值，不再有实际上限限制。

## Summary by Sourcery

Bug Fixes:
- 通过将上限提高到 `Number.MAX_SAFE_INTEGER`，修复了无法输入较大 Bilibili 用户 UID 的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix inability to input large Bilibili user UIDs by raising the upper limit to Number.MAX_SAFE_INTEGER.

</details>